### PR TITLE
Fix TDK image version substitution

### DIFF
--- a/.github/workflows/update_tdk_version.yml
+++ b/.github/workflows/update_tdk_version.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Update image version
         env:
           IMAGE_VERSION: |-
-            "synthesizedio/synthesized-tdk-cli:v${{ env.RELEASE_VERSION }}"
+            synthesizedio/synthesized-tdk-cli:v${{ env.RELEASE_VERSION }}
         run: |
           yq -i '.services.tdk.image = strenv(IMAGE_VERSION)' \
             ./parent-compose.yml

--- a/.github/workflows/update_tdk_version.yml
+++ b/.github/workflows/update_tdk_version.yml
@@ -14,7 +14,7 @@ jobs:
 
       - name: Update image version
         env:
-          IMAGE_VERSION: >
+          IMAGE_VERSION: |-
             "synthesizedio/synthesized-tdk-cli:v${{ env.RELEASE_VERSION }}"
         run: |
           yq -i '.services.tdk.image = strenv(IMAGE_VERSION)' \


### PR DESCRIPTION
In the attempt to appease the linter in the past, the `IMAGE_VERSION` env in the GHA workflow file was changed to use a block scalar. However, the used block scalar style led to the preservation of the trailing '\n', which in turn resulted in `yq` treating this as a multiline and using a block scalar when rendering the Docker Compose file. Docker Compose doesn't understand block scalars, at least in the image version position, so the resulting Docker Compose YAML file did not work.

This change adds the block chomping indicator to strip off the trailing newline. Also, the "folded" style was changed to "literal", as we'd still like to specify image tag on a single line, without any additional whitespace eliding by the YAML reader.