### PR TITLE
Change token to developer's

### DIFF
--- a/.github/workflows/update_tdk_version.yml
+++ b/.github/workflows/update_tdk_version.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Create PR
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.FGT_FOR_RELEASE_COMMITS }}
         run: |
           pr=$(gh pr create --base main \
             --head "update-release-version-v${RELEASE_VERSION}" \


### PR DESCRIPTION
GitHub actions bit can not trigger on-pull-requst checks. If we create the PR on developer's name, the checks should be triggered