### PR TITLE
add csv transformation with error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ postgres/logs
 mysql/logs
 
 sqlite/output/output.db
+csv/datasets/output

--- a/csv/README.md
+++ b/csv/README.md
@@ -1,0 +1,31 @@
+# CSV Demo 
+
+For details, see  https://docs.synthesized.io/tdk/latest/user_guide/integrations/csv
+
+
+
+## Configuration
+
+config.yaml:
+
+```
+default_config:
+  mode: MASKING
+safety_mode: STRICT
+schema_creation_mode: DO_NOT_CREATE
+
+tables:
+   - table_name_with_schema: "public.users"
+     mode: GENERATION
+     target_ratio: 5
+```
+
+
+
+## Running a CSV transformation
+
+````
+export SYNTHESIZED_KEY="{your license key}"
+docker compose run --rm tdk
+````
+

--- a/csv/config.yaml
+++ b/csv/config.yaml
@@ -1,0 +1,9 @@
+default_config:
+  mode: MASKING
+safety_mode: STRICT
+schema_creation_mode: DO_NOT_CREATE
+
+tables:
+   - table_name_with_schema: "public.users"
+     mode: GENERATION
+     target_ratio: 5

--- a/csv/datasets/input/users/data.csv
+++ b/csv/datasets/input/users/data.csv
@@ -1,0 +1,2 @@
+name,nickname
+Alice,""

--- a/csv/docker-compose.yaml
+++ b/csv/docker-compose.yaml
@@ -1,0 +1,27 @@
+services:
+
+  tdk:
+    extends:
+      file: ../parent-compose.yml
+      service: tdk
+    environment:
+      SYNTHESIZED_KEY: ${SYNTHESIZED_KEY}
+      SYNTHESIZED_INPUT_URL: file:///app/datasets/input/
+      SYNTHESIZED_OUTPUT_URL: file:///app/datasets/output/
+      SYNTHESIZED_USERCONFIG_FILE: /app/config.yaml
+      TDK_WORKINGDIRECTORY_PATH: /app/data
+      TDK_WORKINGDIRECTORY_ENABLED: "true"
+      JAVA_TOOL_OPTIONS: >
+        -Dlogging.level.io.synthesized.tdk.executor.lite.LiteTransformer=INFO
+        -Dlogging.level.io.synthesized.tdk=WARN
+        -Dlogging.level.com.zaxxer.hikari=WARN
+        -Dlogging.level.org.reflections=WARN
+        -Dlogging.level.org.jooq=WARN
+        -XX:+UseContainerSupport
+        -XX:MaxRAMPercentage=80.0
+        -Dspring.main.banner-mode=CONSOLE
+        -Dspring.banner.location=file:/app/banner.txt
+    volumes:
+      - ./config.yaml:/app/config.yaml
+      - ./datasets:/app/datasets
+


### PR DESCRIPTION
Hi, this is my demo of csv transformation.

But when TDK reads a CSV file containing empty strings, a java.util.NoSuchElementException occurs. Is there a solution to this?

input csv file:
https://github.com/ryu1/tdk-demo/blob/56811557c59ae6ffcc74699f986d0d6eb6e9aac2/csv/datasets/input/users/data.csv#L2

log:

```
Picked up JAVA_TOOL_OPTIONS: -Dlogging.level.io.synthesized.tdk.executor.lite.LiteTransformer=INFO -Dlogging.level.io.synthesized.tdk=WARN -Dlogging.level.com.zaxxer.hikari=WARN -Dlogging.level.org.reflections=WARN -Dlogging.level.org.jooq=WARN -XX:+UseContainerSupport -XX:MaxRAMPercentage=80.0 -Dspring.main.banner-mode=CONSOLE -Dspring.banner.location=file:/app/banner.txt


  .   ____          _            __ _ _
 /\\ / ___'_ __ _ _(_)_ __  __ _ \ \ \ \
( ( )\___ | '_ | '_| | '_ \/ _` | \ \ \ \
 \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
  '  |____| .__|_| |_|_| |_\__, | / / / /
 =========|_|==============|___/=/_/_/_/

 :: Spring Boot ::                (v3.4.2)

java.util.NoSuchElementException: Key kotlin.String? is missing in the map.
	at kotlin.collections.MapsKt__MapWithDefaultKt.getOrImplicitDefaultNullable(MapWithDefault.kt:24)
	at kotlin.collections.MapsKt__MapsKt.getValue(Maps.kt:369)
	at io.synthesized.tdk.db.meta.csv.CsvMetaProvider.a(CsvMetaProvider.kt:176)
	at io.synthesized.tdk.db.meta.csv.CsvMetaProvider.a(CsvMetaProvider.kt:94)
	at io.synthesized.tdk.db.meta.csv.CsvMetaProvider.a(CsvMetaProvider.kt:1086)
	at kotlin.SynchronizedLazyImpl.getValue(LazyJVM.kt:83)
	at io.synthesized.tdk.db.meta.csv.CsvMetaProvider.getMeta(CsvMetaProvider.kt:72)
	at io.synthesized.tdk.core.config.validation.UserConfigDatabaseValidator.<init>(UserConfigDatabaseValidator.kt:17)
	at io.synthesized.tdk.core.config.converter.SingleDbConfigConverter.<init>(SingleDbConfigConverter.kt:49)
	at io.synthesized.tdk.core.config.converter.ConfigConverter.<init>(ConfigConverter.kt:29)
	at io.synthesized.tdk.executor.SynthesizedExecutor.execute(SynthesizedExecutor.kt:176)
	at io.synthesized.tdk.executor.SynthesizedExecutor.execute$default(SynthesizedExecutor.kt:130)
	at io.synthesized.tdk.cli.CLI.call(CLI.kt:192)
	at io.synthesized.tdk.cli.CLI.call(CLI.kt:34)
	at io.synthesized.tdk.cli.CLI$$SpringCGLIB$$0.call(<generated>)
	at picocli.CommandLine.executeUserObject(CommandLine.java:2045)
	at picocli.CommandLine.access$1500(CommandLine.java:148)
	at picocli.CommandLine$RunLast.executeUserObjectOfLastSubcommandWithSameParent(CommandLine.java:2465)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2457)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2419)
	at picocli.CommandLine$AbstractParseResultHandler.execute(CommandLine.java:2277)
	at picocli.CommandLine$RunLast.execute(CommandLine.java:2421)
	at picocli.CommandLine.execute(CommandLine.java:2174)
	at io.synthesized.tdk.cli.CLI.run(CLI.kt:382)
	at org.springframework.boot.SpringApplication.lambda$callRunner$5(SpringApplication.java:788)
	at org.springframework.util.function.ThrowingConsumer$1.acceptWithException(ThrowingConsumer.java:82)
	at org.springframework.util.function.ThrowingConsumer.accept(ThrowingConsumer.java:60)
	at org.springframework.util.function.ThrowingConsumer$1.accept(ThrowingConsumer.java:86)
	at org.springframework.boot.SpringApplication.callRunner(SpringApplication.java:796)
	at org.springframework.boot.SpringApplication.callRunner(SpringApplication.java:787)
	at org.springframework.boot.SpringApplication.lambda$callRunners$3(SpringApplication.java:772)
	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.accept(ForEachOps.java:183)
	at java.base/java.util.stream.SortedOps$SizedRefSortingSink.end(SortedOps.java:357)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:510)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:150)
	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:173)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:596)
	at org.springframework.boot.SpringApplication.callRunners(SpringApplication.java:772)
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:325)
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:1361)
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:1350)
	at io.synthesized.tdk.cli.CLI$Companion.main(CLI.kt:452)
	at io.synthesized.tdk.cli.CLI.main(CLI.kt)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:569)
	at org.springframework.boot.loader.launch.Launcher.launch(Launcher.java:102)
	at org.springframework.boot.loader.launch.Launcher.launch(Launcher.java:64)
	at org.springframework.boot.loader.launch.JarLauncher.main(JarLauncher.java:40)
```