### PR TITLE
[synthesized-io/tdk#6872] Fix Counts for MySQL

### DIFF
--- a/mysql/docker-compose.yaml
+++ b/mysql/docker-compose.yaml
@@ -63,7 +63,7 @@ services:
       SYNTHESIZED_INPUT_URL: jdbc:mysql://input_db:3306/sakila
       SYNTHESIZED_INPUT_USERNAME: root
       SYNTHESIZED_INPUT_PASSWORD: admin
-      SYNTHESIZED_OUTPUT_URL: jdbc:mysql://output_db:3306/sakila?sessionVariables=sql_mode='NO_AUTO_VALUE_ON_ZERO'
+      SYNTHESIZED_OUTPUT_URL: jdbc:mysql://output_db:3306/sakila
       SYNTHESIZED_OUTPUT_USERNAME: root
       SYNTHESIZED_OUTPUT_PASSWORD: admin
       SYNTHESIZED_USERCONFIG_FILE: /app/config.yaml

--- a/mysql/soda/checks_for_generation_from_scratch.yaml
+++ b/mysql/soda/checks_for_generation_from_scratch.yaml
@@ -5,7 +5,7 @@ checks for address:
   - row_count = 5000
 
 checks for category:
-  - row_count = 256
+  - row_count = 255
 
 checks for city:
   - row_count = 1000
@@ -34,7 +34,7 @@ checks for inventory:
   - row_count = 10000
 
 checks for language:
-  - row_count = 256
+  - row_count = 255
 
 checks for payment:
   - row_count = 20000
@@ -43,9 +43,9 @@ checks for rental:
   - row_count = 20000
 
 checks for staff:
-  - row_count = 256
+  - row_count = 255
   - invalid_percent(email) = 0:
       valid format: email
 
 checks for store:
-  - row_count = 256
+  - row_count = 255


### PR DESCRIPTION
As we now generate integer sequences starting from 1, `tinyint` type (1 byte) doesn't allow storing record with id=256. Here we change expected counts to support current behavior