### PR TITLE
chore(vault): pin hashicorp/vault image to 1.21.4

### DIFF
--- a/vault/docker-compose.yaml
+++ b/vault/docker-compose.yaml
@@ -3,7 +3,7 @@ version: '3.5'
 services:
 
   vault:
-    image: hashicorp/vault
+    image: hashicorp/vault:1.21.4
     command: server -dev
     ports:
       - "9200:8200"
@@ -14,7 +14,7 @@ services:
 
 
   vault-client:
-    image: hashicorp/vault
+    image: hashicorp/vault:1.21.4
     command: sh /vault/run_vault.sh
     volumes:
       - ./run_vault.sh:/vault/run_vault.sh


### PR DESCRIPTION
## Summary

Pin `hashicorp/vault` → `hashicorp/vault:1.21.4` in `vault/docker-compose.yaml` (both `vault` and `vault-client` services).

## Why

`hashicorp/vault:latest` was updated to **2.0.x on 2026-05-19**, which now enforces the `IPC_LOCK` capability and **ignores `SKIP_SETCAP=true` when the container runs as non-root**. The vault server can no longer start in GH Actions runners:

```
vault-1  | Container is running as non-root user, ignoring SKIP_SETCAP
vault-1  | Vault requires the IPC_LOCK capability...
vault-1  | exec: line 116: vault: Operation not permitted
vault-1 exited with code 126
```

With `vault` dead, `vault-client` loops forever on `Trying to connect to vault`, so `service_completed_successfully` never fires, and the `tdk` service hangs until GH Actions kills the job at the 6h timeout.

## Impact

All `test_vault` jobs for the version-bump PRs have been hanging since v1.159:
- PR #245 v1.159.0 — cancelled at 6h
- PR #246 v1.160.0 — cancelled at 6h
- PR #247 v1.161.0 — currently hanging

## Verified locally

With this pin (`hashicorp/vault:1.21.4`, last 1.x stable from 2026-03-05):
- `vault` starts cleanly
- `vault-client` walks through full setup (approle + database secrets engine + static & dynamic roles)
- Exits `0` in ~30s
- `tdk` service unblocks and proceeds

Sample of fixed run:
```
vault-client-1  | Success! Enabled the database secrets engine at: database/
vault-client-1  | Success! Data written to: database/config/postgres_source
vault-client-1  | Success! Data written to: database/config/postgres_target
vault-client-1  | Success! Data written to: database/static-roles/postgres-source-static-role
...
vault-client-1 exited with code 0
```

## Test plan

- [ ] CI passes on all `test_vault` jobs for this PR
- [ ] Once merged, rerun the failing `test_vault` jobs on PR #247 (v1.161.0 bump)

## Follow-ups (out of scope)

- `vault/run_vault.sh` uses `while ! $(vault status &> /dev/null)` which is a corrupt subshell-substitution idiom (should be `until vault status &>/dev/null; do …; done`). Worth cleaning up separately.
- Consider whether to track `hashicorp/vault` 2.x adoption with proper `cap_add: [IPC_LOCK]` instead of pinning forever.